### PR TITLE
Code to arbitrarily restart workloads in Kubernetes based on a cron-job.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+Module designed to help run automated restarts of applications in k8s
+
+A requirement has developed to periodically restart pods in aggregation abstraction layers due to unusual edge cases.
+
+This is often achieved by using the liveness_probe and then adjusting the behavioru to trigger, however this relies on the liveness probe not being used elsewhere in k8s as an actual liveness probe.
+
+This module creates a service account, grants it specific access to the deployment/statefulset/daemonset for invoking `kubectl rollout restart` and provisions a cronjob to restart it.

--- a/cron_job.tf
+++ b/cron_job.tf
@@ -1,0 +1,46 @@
+resource "kubernetes_cron_job" "restart" {
+  metadata {
+    name      = local.instance_name
+    namespace = var.namespace
+
+    labels = {
+      "app.kubernetes.io/component" = "restart-service"
+      "app.kubernetes.io/instance"  = var.instance
+    }
+  }
+
+  spec {
+    concurrency_policy = "Forbid"
+    schedule           = var.schedule
+
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit = 2
+
+        active_deadline_seconds = 600
+
+        template {
+          metadata {}
+          spec {
+            service_account_name = kubernetes_service_account.restart.metadata.0.name
+
+            restart_policy = "Never"
+
+            container {
+              name  = "kubectl"
+              image = "bitnami/kubectl"
+
+              command = [
+                "kubectl",
+                "rollout",
+                "restart",
+                "${var.resource_type}/${var.resource_name}"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/loacls.tf
+++ b/loacls.tf
@@ -1,0 +1,3 @@
+locals {
+  instance_name = "${var.instance}-restart"
+}

--- a/role.tf
+++ b/role.tf
@@ -1,0 +1,19 @@
+resource "kubernetes_role" "restart" {
+  metadata {
+    name      = local.instance_name
+    namespace = var.namespace
+
+    labels = {
+      "app.kubernetes.io/component" = "restart-service"
+      "app.kubernetes.io/instance"  = var.instance
+    }
+  }
+
+  rule {
+    api_groups     = ["apps", "extensions"]
+    resources      = [var.resource_type]
+    resource_names = [var.resource_name]
+    verbs          = ["get", "patch", "list", "watch"]
+  }
+
+}

--- a/role_binding.tf
+++ b/role_binding.tf
@@ -1,0 +1,23 @@
+resource "kubernetes_role_binding" "restart" {
+  metadata {
+    name      = local.instance_name
+    namespace = var.namespace
+
+    labels = {
+      "app.kubernetes.io/component" = "restart-service"
+      "app.kubernetes.io/instance"  = var.instance
+    }
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role.restart.metadata.0.name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.restart.metadata.0.name
+    namespace = var.namespace
+  }
+}

--- a/service_account.tf
+++ b/service_account.tf
@@ -1,0 +1,11 @@
+resource "kubernetes_service_account" "restart" {
+  metadata {
+    name      = local.instance_name
+    namespace = var.namespace
+
+    labels = {
+      "app.kubernetes.io/component" = "restart-service"
+      "app.kubernetes.io/instance"  = var.instance
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,36 @@
+variable "resource_type" {
+  description = <<EOT
+Name of the K8S resource type that you want to restart
+Accepts:
+* deployments
+* statefulsets
+* daemonsets
+EOT
+
+  type = string
+}
+
+variable "resource_name" {
+  description = "Name of resource to touch"
+  type        = string
+}
+variable "namespace" {
+  description = "kubernetes namespace where the resources exist"
+  default     = "default"
+  type        = string
+}
+
+variable "instance" {
+  description = "unique instance name for this module instance to allow this to be used on multiple resources"
+  type        = string
+}
+
+
+variable "schedule" {
+  description = <<EOT
+Cron job schedule for restart
+Accepts standard cron format: m h domo mo dow
+default: 0 * * * *
+EOT
+  default = "0 * * * *"
+}


### PR DESCRIPTION
Code to arbitrarily restart workloads in Kubernetes based on a cron-job.

# Implementation specifics
A cronjob has been created to action K8S api calls to trigger `kubectl rollout restart` commands for a specified workload.

To achieve this, a kubernetes service account is provisioned with RBAC configuration to grant permissions to modify the named workload's definition. This allows kubectl to be executed inside the pod within the job of the cronjob to trigger reload. 

It accepts cron format trigger times and is expected that it should provide the target, as well as the namespace for the workload to be triggered.

Follow up work would include allowing the overriding of the Service account so it doesn't need to create one to action this work.
